### PR TITLE
Implement login page and auth context

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,12 @@ The app uses **React Router**. Main routes:
 
 Components for these pages live under `frontend/src/pages`.
 
+The `LoginPage` allows the admin to authenticate. It posts credentials to
+`/api/auth/login` and stores the returned JWT in `localStorage` as `authToken`.
+An `AuthContext` provides `login` and `logout` helpers and exposes an
+`isAuthenticated` flag. After successful login the user is redirected to
+`/admin`.
+
 The frontend communicates with the backend via REST API requests to `http://localhost:5000/api/*`. CORS is enabled on the backend (allowing `http://localhost:3000`) so the React app can make requests during development.
 
 The frontend and backend are separate projects and communicate only via HTTP.

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -39,7 +39,9 @@ Both projects must have dependencies installed (`npm install`) in their respecti
 - Mongoose models go in `backend/models/`.
 - React components and pages are under `frontend/src/`, using React Router for navigation.
 - All API responses are JSON.
-- JWT-based authentication will be introduced later.
+- JWT-based authentication is used. The frontend obtains a token via the `/login` page and saves it in `localStorage` under `authToken`.
+- The React app exposes an `AuthContext` that stores the token and provides `login` and `logout` helpers to components.
+- After a successful login the user is redirected to the `/admin` dashboard.
 
 # Keeping This Document Updated
 

--- a/frontend/src/AuthContext.js
+++ b/frontend/src/AuthContext.js
@@ -1,0 +1,32 @@
+import React, { createContext, useState, useEffect } from 'react';
+
+export const AuthContext = createContext();
+
+export function AuthProvider({ children }) {
+  const [token, setToken] = useState(() => localStorage.getItem('authToken'));
+
+  useEffect(() => {
+    if (token) {
+      localStorage.setItem('authToken', token);
+    } else {
+      localStorage.removeItem('authToken');
+    }
+  }, [token]);
+
+  const login = (newToken) => {
+    setToken(newToken);
+  };
+
+  const logout = () => {
+    setToken(null);
+  };
+
+  const value = {
+    token,
+    isAuthenticated: !!token,
+    login,
+    logout,
+  };
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -3,11 +3,14 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
+import { AuthProvider } from './AuthContext';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
-    <App />
+    <AuthProvider>
+      <App />
+    </AuthProvider>
   </React.StrictMode>
 );
 

--- a/frontend/src/pages/LoginPage.js
+++ b/frontend/src/pages/LoginPage.js
@@ -1,7 +1,65 @@
-import React from 'react';
+import React, { useState, useContext } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { AuthContext } from '../AuthContext';
 
 function LoginPage() {
-  return <h1>Login Page</h1>;
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const { login } = useContext(AuthContext);
+  const navigate = useNavigate();
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError('');
+
+    try {
+      const res = await fetch('http://localhost:5000/api/auth/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json().catch(() => null);
+        throw new Error(data?.message || 'Login failed');
+      }
+
+      const data = await res.json();
+      login(data.token);
+      navigate('/admin');
+    } catch (err) {
+      setError(err.message);
+    }
+  };
+
+  return (
+    <div>
+      <h1>Login</h1>
+      <form onSubmit={handleSubmit}>
+        <div>
+          <label htmlFor="email">Email:</label>
+          <input
+            id="email"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+          />
+        </div>
+        <div>
+          <label htmlFor="password">Password:</label>
+          <input
+            id="password"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+        </div>
+        {error && <p style={{ color: 'red' }}>{error}</p>}
+        <button type="submit">Login</button>
+      </form>
+    </div>
+  );
 }
 
 export default LoginPage;


### PR DESCRIPTION
## Summary
- add `AuthContext` to hold JWT token and expose login/logout helpers
- wrap app in `AuthProvider`
- implement login form that calls `/api/auth/login` and stores the token
- update documentation for new login flow

## Testing
- `npm test -- --watchAll=false --passWithNoTests` in `frontend`
- `npm test` in `backend` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68827f51756c8325b5532b31db18901f