### PR TITLE
Implement login endpoint with JWT

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,13 @@ This repository contains a simple Node.js backend located in the `backend/` dire
 
 `/api/health` returns `{"status":"OK"}` to verify the server is up.
 
+### Authentication Endpoints
+
+- `POST /api/auth/login` – Body: `{ "email": "...", "password": "..." }`. On success returns `{ "token": "<jwt>" }`. Include this token in the `Authorization: Bearer <token>` header when calling protected endpoints.
+- `GET /api/secret` – example protected route that requires a valid JWT and returns secret data.
+
+Only an admin user exists by default. Set `ADMIN_EMAIL` and `ADMIN_PASSWORD` in `.env` to configure the credentials seeded on first run.
+
 ## Project Structure
 
 - `backend/index.js` – Main entry and mounts routes.

--- a/backend/index.js
+++ b/backend/index.js
@@ -13,6 +13,8 @@ app.use(cors({ origin: 'http://localhost:3000' }));
 app.use(express.json());
 
 app.use('/api', require('./routes/health'));
+app.use('/api', require('./routes/auth'));
+app.use('/api', require('./routes/secret'));
 
 async function startServer() {
   try {

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -1,0 +1,31 @@
+const express = require('express');
+const jwt = require('jsonwebtoken');
+const User = require('../models/User');
+
+const router = express.Router();
+
+/**
+ * POST /api/auth/login
+ * Authenticate user and return JWT token.
+ */
+router.post('/auth/login', async (req, res) => {
+  const { email, password } = req.body;
+  const user = await User.findOne({ email });
+  if (!user) {
+    return res.status(401).json({ message: 'Invalid credentials' });
+  }
+
+  const valid = await user.comparePassword(password || '');
+  if (!valid) {
+    return res.status(401).json({ message: 'Invalid credentials' });
+  }
+
+  const token = jwt.sign(
+    { id: user._id, role: user.role, email: user.email },
+    process.env.JWT_SECRET,
+    { expiresIn: '1h' }
+  );
+  res.json({ token });
+});
+
+module.exports = router;

--- a/backend/routes/secret.js
+++ b/backend/routes/secret.js
@@ -1,0 +1,13 @@
+const express = require('express');
+const auth = require('../middleware/auth');
+
+const router = express.Router();
+
+/**
+ * Dummy protected route used for testing JWT auth.
+ */
+router.get('/secret', auth, (req, res) => {
+  res.json({ data: 'secret data' });
+});
+
+module.exports = router;

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -39,7 +39,13 @@ Both projects must have dependencies installed (`npm install`) in their respecti
 - Mongoose models go in `backend/models/`.
 - React components and pages are under `frontend/src/`, using React Router for navigation.
 - All API responses are JSON.
-- JWT-based authentication will be introduced later.
+- JWT-based authentication is now implemented.
+
+## API Endpoints
+
+- `GET /api/health` – returns `{ "status": "OK" }`.
+- `POST /api/auth/login` – accepts `email` and `password`; returns `{ token }` on success. Include `Authorization: Bearer <token>` when calling protected routes.
+- `GET /api/secret` – example protected endpoint that responds with secret data when authenticated.
 
 # Keeping This Document Updated
 


### PR DESCRIPTION
## Summary
- implement `/api/auth/login` route to issue JWTs
- add `/api/secret` protected route for testing
- wire new routes into Express app
- document authentication endpoints and usage

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68827f3d09048325a255f8b65ca019b7