### PR TITLE
Add Post data model

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,3 +77,19 @@ An `AuthContext` provides `login` and `logout` helpers and exposes an
 The frontend communicates with the backend via REST API requests to `http://localhost:5000/api/*`. CORS is enabled on the backend (allowing `http://localhost:3000`) so the React app can make requests during development.
 
 The frontend and backend are separate projects and communicate only via HTTP.
+
+## Data Models
+
+### Post
+
+The `backend/models/Post.js` file defines the Post schema used for blog
+entries. Fields:
+
+- `title` (String, required) – title of the post.
+- `content` (String, required) – the main body text.
+- `author` (String) – optional name of the author.
+- `published` (Boolean, default `false`) – whether the post is visible.
+- `createdAt` and `updatedAt` timestamps are managed automatically.
+
+Currently the `author` is stored as a simple string, but it could later be
+expanded to reference a `User` document.

--- a/backend/index.js
+++ b/backend/index.js
@@ -4,6 +4,7 @@ const mongoose = require('mongoose');
 require('dotenv').config();
 
 const User = require('./models/User');
+const Post = require('./models/Post');
 
 const app = express();
 const port = process.env.PORT || 5000;

--- a/backend/models/Post.js
+++ b/backend/models/Post.js
@@ -1,0 +1,13 @@
+const mongoose = require('mongoose');
+
+const postSchema = new mongoose.Schema(
+  {
+    title: { type: String, required: true },
+    content: { type: String, required: true },
+    author: { type: String },
+    published: { type: Boolean, default: false }
+  },
+  { timestamps: true }
+);
+
+module.exports = mongoose.model('Post', postSchema);


### PR DESCRIPTION
## Summary
- create `Post` Mongoose model for blog posts
- register the model in the server startup
- document the Post fields in `AGENTS.md`

## Testing
- `npm install`
- `node -e "require('./models/Post'); console.log('ok')"`

------
https://chatgpt.com/codex/tasks/task_e_6887656314b08325aa74984d7a3e81b9